### PR TITLE
[HOTFIX #82] - response body of id field added for [/auth/renew]

### DIFF
--- a/src/routes/authentication.ts
+++ b/src/routes/authentication.ts
@@ -476,7 +476,9 @@ authenticationRouter.get('/renew', async (req, res, next) => {
       cookieOption.path = '/auth';
       res.cookie('X-REFRESH-TOKEN', refreshToken, cookieOption);
     }
-    res.status(200).send();
+    res.status(200).send({
+      id: tokenVerifyResult.content.id,
+    });
   } catch (e) {
     next(e);
   }

--- a/test/testCases/auth/get.renew.test.ts
+++ b/test/testCases/auth/get.renew.test.ts
@@ -296,6 +296,7 @@ describe('GET /auth/renew', () => {
       .set({Origin: 'https://collegemate.app'})
       .send({isSignup: true});
     expect(response.status).toBe(200);
+    expect(response.body.id).toBe('newAccount@wisc.edu');
 
     // Check Cookie & Token Information
     const jwtOption: jwt.VerifyOptions = {algorithms: ['HS512']};
@@ -326,6 +327,7 @@ describe('GET /auth/renew', () => {
       .set('Cookie', [`X-REFRESH-TOKEN=${refreshTokenMap.soonExpired}`])
       .set({'X-APPLICATION-KEY': '<Android-App-v1>'});
     expect(response.status).toBe(200);
+    expect(response.body.id).toBe('existing@wisc.edu');
 
     // Check Cookie & Token Information
     const jwtOption: jwt.VerifyOptions = {algorithms: ['HS512']};
@@ -380,6 +382,7 @@ describe('GET /auth/renew', () => {
       .set({'X-APPLICATION-KEY': '<Android-App-v1>'})
       .send({isSignup: true});
     expect(response.status).toBe(200);
+    expect(response.body.id).toBe('existing@wisc.edu');
 
     // Check Cookie & Token Information
     const jwtOption: jwt.VerifyOptions = {algorithms: ['HS512']};
@@ -409,6 +412,7 @@ describe('GET /auth/renew', () => {
       .set('Cookie', [`X-REFRESH-TOKEN=${refreshTokenMap.soonExpired}`])
       .set({Origin: 'https://collegemate.app'});
     expect(response.status).toBe(200);
+    expect(response.body.id).toBe('existing@wisc.edu');
 
     // Check Cookie & Token Information
     const jwtOption: jwt.VerifyOptions = {algorithms: ['HS512']};
@@ -462,6 +466,7 @@ describe('GET /auth/renew', () => {
       .set('Cookie', [`X-REFRESH-TOKEN=${refreshTokenMap.valid}`])
       .set({Origin: 'https://collegemate.app'});
     expect(response.status).toBe(200);
+    expect(response.body.id).toBe('existing@wisc.edu');
 
     // Check Cookie & Token Information
     const jwtOption: jwt.VerifyOptions = {algorithms: ['HS512']};


### PR DESCRIPTION
Close #82 

## When Reviewing this PR, please
- checkout `feature-#82-steve` branch
- Thoroughly read the edits and compare it with API documentation
- Thoroughly read added test cases
- Run the test code. Check the behavior and code coverage

## What has been edited
 - [/auth/renew] response body of id field added